### PR TITLE
ci: add deploy workflow for DigitalOcean + pm2 restart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: deploy-production
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -24,9 +24,9 @@ jobs:
           script_stop: true
           script: |
             set -e
-            cd /opt/nyc-counter
+            cd /home/qruser/qr-madness
             git fetch origin
             git reset --hard origin/main
             npm ci --omit=dev
-            pm2 restart nyc-counter
+            pm2 restart nyc-qr-counter
             pm2 save

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to DigitalOcean
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DO_HOST }}
+          username: ${{ secrets.DO_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          port: ${{ secrets.DO_PORT || 22 }}
+          script_stop: true
+          script: |
+            set -e
+            cd /opt/nyc-counter
+            git fetch origin
+            git reset --hard origin/main
+            npm ci --omit=dev
+            pm2 restart nyc-counter
+            pm2 save


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds an automated production deploy triggered on `main` pushes that force-resets the server repo and restarts `pm2`, so a misconfiguration or bad commit can impact production availability.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/deploy.yml`) to deploy to a DigitalOcean server over SSH on pushes to `main` (and manual dispatch), with concurrency to prevent overlapping deploys.
> 
> The job pulls the latest `origin/main` on the server via `git reset --hard`, runs `npm ci --omit=dev`, then restarts and saves the `pm2` process (`nyc-counter`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9efbbdea3342373013e18e37878f4e402e1752d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->